### PR TITLE
Added link to new YOLO documentation page

### DIFF
--- a/subteams/vision/vision.md
+++ b/subteams/vision/vision.md
@@ -47,6 +47,7 @@ pip install <package_name>
 - [NumPy](/docs/vision/numpy/)
 - [OpenCV](/docs/vision/opencv/)
 - [Pytesseract](/docs/vision/pytesseract/)
+- [YOLO ML](/docs/vision/yolo_ml/)
 
 ## Past Competition Vision Code
 


### PR DESCRIPTION
Added a link to `subteams/vision/yolo_ml/` in `subteams/vision/vision.md` that I didn't know I needed to add before.